### PR TITLE
chore: consistent names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 # Default to the read only token - the read/write token will be present on GitHub Actions.
 # It's set as a secure environment variable in the .travis.yml file
-PACTICIPANT := "example-cypress-consumer"
+PACTICIPANT := "example-consumer-cypress"
 GITHUB_WEBHOOK_UUID := "04510dc1-7f0a-4ed2-997d-114bfa86f8ad"
 CYPRESSRUNCMD=npx cypress run
 CYPRESSGUICMD=npx cypress open
 PACT_BROKER_BASE_URL?=https://testdemo.pactflow.io
 PACT_BROKER_USERNAME?=dXfltyFMgNOFZAxr8io9wJ37iUpY42M
 PACT_BROKER_PASSWORD?=O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1
-REACT_APP_API_BASE_URL?=${PACT_BROKER_BASE_URL}/pacts/provider/pactflow-example-provider/consumer/example-cypress-consumer/latest/stub
+REACT_APP_API_BASE_URL?=${PACT_BROKER_BASE_URL}/pacts/provider/pactflow-example-provider/consumer/example-consumer-cypress/latest/stub
 PACT_CLI="docker run --rm -v ${PWD}:${PWD} -e PACT_BROKER_BASE_URL -e PACT_BROKER_TOKEN pactfoundation/pact-cli:latest"
 
 # Only deploy from master

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository shows how Pact, Pactflow and Cypress could work together to prov
 
 The end-to-end project is based off the Pactflow CI/CD workshop at https://docs.pactflow.io/docs/workshops/ci-cd/.
 
-It is using a public tenant on Pactflow, which you can access [here](https://testdemo.pactflow.io/) using the credentials `dXfltyFMgNOFZAxr8io9wJ37iUpY42M`/`O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1`. The latest version of the Example Consumer/Example Provider pact is published [here](https://testdemo.pactflow.io/pacts/provider/pactflow-example-provider/consumer/example-cypress-consumer/latest).
+It is using a public tenant on Pactflow, which you can access [here](https://testdemo.pactflow.io/) using the credentials `dXfltyFMgNOFZAxr8io9wJ37iUpY42M`/`O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1`. The latest version of the Example Consumer/Example Provider pact is published [here](https://testdemo.pactflow.io/pacts/provider/pactflow-example-provider/consumer/example-consumer-cypress/latest).
 
 _NOTE: this repository took inspiration from the great work over at https://github.com/YOU54F/cypress-pact._
 
@@ -21,8 +21,8 @@ _NOTE: this repository took inspiration from the great work over at https://gith
 The following is an over simplified view of how this would work in a full end-to-end workflow:
 
 1. Cypress tests the React website running at `http://localhost:3000`.
-1. Pact tests within the Cypress suite mock out network calls, generating a contract file that captures the interactions between the two systems. The contract is stored in `pacts/example-cypress-consumer-pactflow-example-provider.json` if test run was successful.
-2. The contract is then published to a publicly available Pactflow account at https://testdemo.pactflow.io/pacts/provider/pactflow-example-provider/consumer/example-cypress-consumer/latest (login with username: `dXfltyFMgNOFZAxr8io9wJ37iUpY42M` / password: `O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1`, example build https://github.com/pactflow/example-consumer-cypress/workflows)
+1. Pact tests within the Cypress suite mock out network calls, generating a contract file that captures the interactions between the two systems. The contract is stored in `pacts/example-consumer-cypress-pactflow-example-provider.json` if test run was successful.
+2. The contract is then published to a publicly available Pactflow account at https://testdemo.pactflow.io/pacts/provider/pactflow-example-provider/consumer/example-consumer-cypress/latest (login with username: `dXfltyFMgNOFZAxr8io9wJ37iUpY42M` / password: `O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1`, example build https://github.com/pactflow/example-consumer-cypress/workflows)
 3. Provider build is triggered by a webhook to validate the contract that was just published (e.g. https://github.com/pactflow/example-provider/workflows).
 4. Run `can-i-deploy` to see if the Web App is compatible with the Product API and if it is safe to release to production.
 

--- a/cypress-stubbed.json
+++ b/cypress-stubbed.json
@@ -6,7 +6,7 @@
     "providers": [
       {
         "provider": "pactflow-example-provider",
-        "baseUrl": "/pacts/provider/pactflow-example-provider/consumer/example-cypress-consumer/latest/stub"
+        "baseUrl": "/pacts/provider/pactflow-example-provider/consumer/example-consumer-cypress/latest/stub"
       }
     ]
   }

--- a/cypress/integration/test/products.js
+++ b/cypress/integration/test/products.js
@@ -13,7 +13,7 @@ describe("Product page", () => {
   describe("when products exist", () => {
     before(() => {
       cy.mockServer({
-        consumer: "example-cypress-consumer",
+        consumer: "example-consumer-cypress",
         provider: 'pactflow-example-provider',
       }).then(opts => {
         server = opts

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -59,7 +59,7 @@ const findProviderInConfig = (provider) => {
 };
 
 const basePathForProvider = (server) => {
-  // e.g. in this example project it will be /pacts/provider/pactflow-example-provider/consumer/example-cypress-consumer/latest/stub as we are using Pactflow stubs
+  // e.g. in this example project it will be /pacts/provider/pactflow-example-provider/consumer/example-consumer-cypress/latest/stub as we are using Pactflow stubs
   return R.propOr("", 'baseUrl', findProviderInConfig(server.provider))
 };
 


### PR DESCRIPTION
- change name from example-cypress-cypress to example-consumer-cypress to match repo

ideally it wants pactflow as a prefix but we need to get the bi-directional convention down as it will clash with the cypress bdc example